### PR TITLE
Fix #14 Fixing PayPal interstitial links

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardDNS/issues/14
+||epl.paypal-communication.com^
 ! https://github.com/easylist/easylist/issues/2811
 ||stripe.network^$third-party
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28681


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardDNS/issues/14