### PR TITLE
Fix lemonde.fr

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/33122
+||xiti.com^
 ! https://forum.adguard.com/index.php?threads/www-pixelsurplus-com-trackcmp-net.31652
 ||trackcmp.net^
 ! Fixing streamplay.to


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/33122

Rule is from Spyware filter.