### PR TITLE
fix thecounter.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://forum.adguard.com/index.php?threads/false-positive-thecounter-com.32533/
+||thecounter.com^
 ! https://forum.adguard.com/index.php?threads/31996/
 ||rs6.net^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33829


### PR DESCRIPTION
https://forum.adguard.com/index.php?threads/false-positive-thecounter-com.32533/

Site is in Spyware filter, unsure if we should remove it from there already.