### PR TITLE
Fix #93 pravda.com.ua

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/93
+||loadercdn.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/91
 ||advcash.com^
 ! https://forum.adguard.com/index.php?threads/shutterstock-7eer-net.32985/


### PR DESCRIPTION
loadercdn.com should not be blocked completely.