### PR TITLE
mql5.com fix #113 

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/113
+||mql5.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/111
 ||enter-system.com^
 ! https://forum.adguard.com/index.php?threads/34094/


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/113

there are already such rules:
`||content.mql5.com^$third-party` — in Russian filter
`||content.mql5.com^` — in SDN filter

so `||mql5.com^` might be excluded 