### PR TITLE
Fix com.pontomobi.smiles 

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/39306
+||ipify.org^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/119
 ||grabo.bg^
 ! Unblocking report-uri.com web site


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/39306
ipify.org is blocked by EasyList(and SDN filter). Should we exclude it in this case? At the moment one app is broken.