### PR TITLE
Fix mybluemix.net

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,5 +1,7 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39674 
 ||stats.lt^
+! blocked by DNS
+||mybluemix.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/119
 ||grabo.bg^
 ! Unblocking report-uri.com web site

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,6 +1,6 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39674 
 ||stats.lt^
-! blocked by DNS
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/139
 ||mybluemix.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/119
 ||grabo.bg^


### PR DESCRIPTION
It came from support. User says that his applications on mybluemix.net with adguard dns servers get server not found. If he switch to comcast dns servers it resolves the problem.