### PR TITLE
Fixing plistaWidget DNS block

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,9 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/41294
+||lasagneandands.com^
+||hotdogsandads.com^
+||thisisacoolthing.com^
+||meatballsandads.com^
+||pizzaandads.com^
 ! https://github.com/AdguardTeam/AdGuardDNS/issues/51
 ||tms-st.cdn.ngenix.net^
 ||ngenix.net^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/41294

Sites are mainly used only for plistaWidget bmp file detection, so they can reinject ads.