### PR TITLE
Fix #149 nikkei app

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/149
+||n8s.jp^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/147
 ||geni.us^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/144 


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/149
n8s.jp is not used for ads only