### PR TITLE
Removed spaces at the end of strings

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,5 +1,5 @@
 ! Fixing the issue with "Wi-Fi" connection mark when you configure private DNS on Android 9
-! Once you enable private DNS, Android 9 starts resolving random domains looking like 
+! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 ! Fixing redirects through guce.advertising.com (www.engadget.com, www.huffpost.com)

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,10 +1,10 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/151
-||macromill.com^ 
+||macromill.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/149
 ||n8s.jp^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/147
 ||geni.us^
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/144 
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/144
 ||affirm.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/138
 ||anexia-it.com^
@@ -29,7 +29,7 @@
 ||mediametrics.ru^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/126
 ||uralweb.ru^
-! https://github.com/AdguardTeam/AdguardFilters/issues/39674 
+! https://github.com/AdguardTeam/AdguardFilters/issues/39674
 ||stats.lt^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/139
 ||mybluemix.net^

--- a/Filters/rules.txt
+++ b/Filters/rules.txt
@@ -1,6 +1,6 @@
 !
 ! Tracking
-! 
+!
 ! replacing ||bpmonline.com^ from easyprivacy
 *.bpmonline.com^
 ||adc.9news.com.au^


### PR DESCRIPTION
Exclusion of `||macromill.com^` with space at the end is not working