### PR TITLE
fix #180

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/180
+||ntv.io^
+||episerver.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/23
 ||sas.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/174


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/180

<details>
  <summary>mimecast.com:</summary>

![slbdzd8l waikk](https://user-images.githubusercontent.com/45171506/70423888-74256d00-1a7f-11ea-9d3e-c42100cb00d8.png)


</details>

<details>
  <summary>teslarati.com:</summary>

![slbdzd8l 5q4el](https://user-images.githubusercontent.com/45171506/70423892-77205d80-1a7f-11ea-98b2-76f4bfe86733.png)


</details>