### PR TITLE
Fix #187 pathe.emsecure.net

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/187
+@@||pathe.emsecure.net^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/183
 @@||feed.adrelayer.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/168

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,10 +2,10 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/190
-@@||awin1.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/187
 @@||pathe.emsecure.net^|
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/190
+@@||awin1.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/185
 @@||app.adjust.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/183

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,8 +2,12 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/190
+@@||awin1.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/187
 @@||pathe.emsecure.net^|
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/185
+@@||app.adjust.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/183
 @@||feed.adrelayer.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/168


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/187
Whole emsecure.net should not be excluded.