### PR TITLE
fix #192 - authorization on justwatch.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,8 +2,6 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/192
-@@||i.tw.cx^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/190
 @@||awin1.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/183

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/192
+@@||i.tw.cx^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/190
 @@||awin1.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/183

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/192
+||tw.cx^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/180
 ||ntv.io^
 ||episerver.net^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/192

`||tw.cx^` comes from EasyPrivacy, which blocks request to `i.tw.cx` and it breaks FB authorization on justwatch.com. 

but after exclusion we'll block tracking by `||e.tw.cx^` from our Privacy filter