### PR TITLE
fix #195 — forexprostools.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/195
+||forexprostools.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/192
 ||tw.cx^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/180


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/195

there are a lot of different subdomains requests that's why I'm not sure about exception
https://publicwww.com/websites/forexprostools.com/
