### PR TITLE
fix #219 - fas.st short links

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/219
+@@||cj.dotomi.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/199
 @@||radiofrance.targetspot.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/187

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/219
+||dpbolvw.net^
 ! https://github.com/AdguardTeam/AdGuardDNS/issues/37
 ||auditude.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/215
@@ -9,7 +11,6 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/208
 ||tmearn.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/204
-||cj.dotomi.com^
 ||emjcd.com^
 ! Fixing tv-tokyo.co.jp, blocked by CNAME
 ||durasite.net^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/219

for now `||cj.dotomi.com^` from exclusions.txt does not help because there is no such rule in SDN filter, so it should be added to exceptions

or we can simply remove `||dotomi.com^`-rules
