### PR TITLE
Fix #222 search.epson.jp

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/222 
+||marsflag.com^
 ! Do not break clicks through the MS redirect service 
 ||click.engage.xbox.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/219


### PR DESCRIPTION
`||c.marsflag.com^` will not be removed from SDN filter.
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/8361299/72733627-defab580-3ba0-11ea-975a-e8b65fd51321.png)

</details>