### PR TITLE
Fix https://github.com/AdguardTeam/AdguardFilters/issues/49614

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/49614
+||sp-prod.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/226
 ||mybannermaker.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/222 


### PR DESCRIPTION
It seems that blocking `sp-prod.net` (it's blocked by `EasyPrivacy`) causes that it's impossible to accept cookie notice on `spiegel.de`, so website is not accessible.