### PR TITLE
Fix #233 zooplus.de

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/233
+||res-x.com^
 ! Breaks Yahoo shopping app
 ||shopping.yahooapis.jp^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/49614


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/233