### PR TITLE
Fix animeout.xyz

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -44,8 +44,10 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/174
 ||buyeasy.by^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/170
+! https://github.com/AdguardTeam/AdGuardDNS/issues/79
 ! Blocking these IP address were also breaking legitimate websites:
 ! Spotify, Pokemon Go
+||51.158.
 ||35.
 ||104.
 ||130.211.


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardDNS/issues/79
whole hosting is blocked in EasyList