### PR TITLE
Fix onet.pl

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! Fixing video player on onet.pl
+||sgqcvfjvr.onet.pl^
 ! Unblock ipgeolocation.io (not analytics)
 ||ipgeolocation.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/233


### PR DESCRIPTION
This rule `||sgqcvfjvr.onet.pl^` is from `EasyPrivacy` and it breaks video player on onet.pl.
Example - `https://sport.onet.pl/pilka-nozna/liga-wloska/piotr-zielinski-i-arkadiusz-milik-odejda-z-napoli/sx204z4?srcc=ucs&utm_v=2`
<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/29142494/75473087-d746e180-5994-11ea-9027-6f5dd55dbb8c.png)

</details>

Similar issue on vod.pl - `https://vod.pl/programy-onetu/7-metrow-pod-ziemia-zawod-psychoterapeuta/fs2fvg3` - video player doesn't work.

It also causes that images on komputerswiat.pl doesn't load - `https://www.komputerswiat.pl/aktualnosci/aplikacje/bank-pekao-szykuje-zmiany-w-aplikacji-oto-co-ma-znalezc-sie-w-peopay-40/176p0py?srcc=ucs&utm_v=2`
<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/29142494/75473210-0a897080-5995-11ea-9a81-183f3ad7619e.png)

</details>
