### PR TITLE
Fix #289 - Fixing Google Shop and Google Ads in search results

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,12 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/289
+! Fixing Google Shop and Google Ads in search results.
+! These ads cannot be hidden on the DNS-level, so we should not break clicks on the adverts
+@@||pagead.l.doubleclick.net^|
+@@||www.googleadservices.com^|
+@@||googleadapis.l.google.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/287
 @@||my.tealiumiq.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/267


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/289
* these rules are not new. They was removed recently.