### PR TITLE
Fix #296 click.mailsf.coinpayments.net

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/296
+@@||click.mailsf.coinpayments.net^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/289
 ! Fixing Google Shop and Google Ads in search results.
 ! These ads cannot be hidden on the DNS-level, so we should not break clicks on the adverts


### PR DESCRIPTION
Not sure, probably we can exclude `||exacttarget.com^` (for `click.virt.s10.exacttarget.com`)
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/296