### PR TITLE
fix #312 search.rakuten.co.jp

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/312
+@@||grp07.ias.rakuten.co.jp^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/306
 @@||click.dream.snhu.edu^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/304


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/312

So far I don't suggest to exclude `ias.rakuten.co.jp` as this domain delivers many ad-scripts and `grp07` part has been stable for almost a year.

AdGuard Extension without AGDNS is not affected, but maybe Brave will be affected so better to add `$third-party` to the Japanese filter rule
`||ias.rakuten.co.jp^`