### PR TITLE
Fix #333 click.messages.webmd.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -4,15 +4,7 @@
 !
 ! Blocked by exacttarget.com alias
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333
-@@||click.messages.webmd.com^|
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/324
-@@||click.promotion.flyscoot.com^|
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/316
-@@||click.bookdepoemail.com^|
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/306
-@@||click.dream.snhu.edu^|
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/296
-@@||click.mailsf.coinpayments.net^|
+@@||click.virt.s*.exacttarget.com^|
 !
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/312
 @@||grp07.ias.rakuten.co.jp^|

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -3,6 +3,8 @@
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 ! Blocked by exacttarget.com alias
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333
+@@||click.messages.webmd.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/324
 @@||click.promotion.flyscoot.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/316


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333
~or, probably, we can add just `@@||click.virt.s*.exacttarget.com^|` and replace similar exclusions?~

Replaced by this rule.

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/8361299/81864470-5c459e00-9575-11ea-94b4-9826b1831a0d.png)

</details>
