### PR TITLE
Fix #336 links.nypost.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/336
+@@||email-link-tracking.maropost.com^|
 ! Blocked by exacttarget.com alias
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333
 @@||click.virt.s*.exacttarget.com^|

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,8 +2,6 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/336
-@@||email-link-tracking.maropost.com^|
 ! Blocked by exacttarget.com alias
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333
 @@||click.virt.s*.exacttarget.com^|

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/336
+||maropost.com^
 ! https://forum.adguard.com/index.php?threads/38369/
 ||ipstack.com^
 ! usa.experian.com is broken after authorization


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/336
Fixing email redirects in subscriptions.