### PR TITLE
Fix #345 click.simba.taobao.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -6,6 +6,9 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333
 @@||click.virt.s*.exacttarget.com^|
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/345
+! Blocked by alimama.com alias
+@@||click.simba.taobao.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/340
 @@||cs.silverpop.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/312


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/345
Here is an example how it used
https://www.facebook.com/486913114664583/photos/httpclicksimbataobaocomcc_imspma230r11723mn90ixpc5aed0acs1044185278k313e2fopbomy/758483084174250/