### PR TITLE
Fix #354 informz.net

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/354
+||informz.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/351
 ||alitems.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/348


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/354
Not a tracker. Used in email subscribtions etc. For example https://sherwood-apsa.informz.net/informzdataservice/onlineversion/ind/bWFpbGluZ2luc3RhbmNlaWQ9ODI1MDcyMiZzdWJzY3JpYmVyaWQ9MTA2MTMwNjY2Ng==
https://community.informz.net/home