### PR TITLE
fix afiliados.hostgator.com.br https://github.com/AdguardTeam/AdguardFilters/issues/58009

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/58009
+||afiliados.hostgator.com.br^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57997
 ||magnetmail1.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/367


### PR DESCRIPTION
Users cannot visit the site to login or registering for affiliate program.

https://github.com/AdguardTeam/AdguardFilters/issues/58009