### PR TITLE
Fix #389 sojern.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/389
+||sojern.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/387
 ||prf.hn^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/376


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/389
two subdomains used for tracking(blocked in TPF)