### PR TITLE
Added AdGuard Base filter's "Foreign" file

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -19,6 +19,13 @@
       "transformations": ["RemoveModifiers", "Validate"]
     },
     {
+      "name": "AdGuard Base filter ad servers foreign",
+      "source": "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/EnglishFilter/sections/foreign.txt",
+      "type": "adblock",
+      "exclusions_sources": ["Filters/exclusions.txt"],
+      "transformations": ["RemoveModifiers", "Validate"]
+    },
+    {
       "name": "AdGuard Base filter cryptominers",
       "source": "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/EnglishFilter/sections/cryptominers.txt",
       "type": "adblock",


### PR DESCRIPTION
After looking through https://github.com/AdguardTeam/AdguardFilters/commit/df72d20df98c999b8d54f81b1e8b86c39faa39ae and seeing that foreign adservers in AdGuard Base are placed in the "Foreign" file and not the "Adservers" file, I double-checked if the "Foreign" file's entries were included in AdGuard DNS, which they weren't. So I decided to include them now.

If this PR gets accepted, this'd add another ~45 entries to AdGuard DNS Filter, primarily:
```
||gjc.gjirafa.com^
||caiteesh.net^
||code.ainsyndication.com^
||adsy.mail.bg^
||adblock.sina.cn^
||cdxyb.cn^
||go.gotourls.bid^
||adbot.tw^
||symaa.cn^
||hbnygj.com^
||bobo.xmwty.com^
||dota.sykty.com^
||tns.simba.taobao.com^
||cdnny.com^
||banner.mob.hr^
||bannery.navratdoreality.cz^
||a.b.napiszar.com^
||adf.acrosspf.com^
||ap.delfi.ee^
||ado.delfi.ee^
||sabavision.com^
||llog.pl^
||bsxmuny.wp.pl^
||fusion.sydsvenskan.se^
||ad.juksy.com^
||ysx8.vip^
||rabc1.iteye.com^
||hyz86.com^
||ere.wew.92kkdy.cc^
||www5.oss-cn-hangzhou.aliyuncs.com^
||lulu.dian500.com.cn^
||ad.52av.tv^
||affiliate.k4.tinhte.vn^
://8ox.cn/
||embed.dugout.com^
||ads1-adselo.com^
||uerzyr.cn^
||juejdkio.com^
||subs.vingd.com^
||rsz.sk^
||cfs1.uzone.id^
||jor-el.net^
||stream.spongead.com^
||innorame.com^
||hbplatform.com^
```