### PR TITLE
Unblock redir.tradedoubler.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -83,6 +83,7 @@
 ! https://forum.adguard.com/index.php?threads/23410/page-7#post-165504
 @@||nineto5mac-d.openx.net^|
 ! https://github.com/AdguardTeam/AdguardDNS/issues/192
+@@||redir.tradedoubler.com^|
 @@||clk*.tradedoubler.com^|
 ! https://forum.adguard.com/index.php?threads/27021/
 @@||href.li^|


### PR DESCRIPTION
Related to this issue - https://github.com/AdguardTeam/AdguardFilters/issues/63518 and this https://github.com/AdguardTeam/AdGuardSDNSFilter/commit/01f4f8d9a05f3101adfa01d9ef34d1fce396607b


Steps to reproduce:
1. Go here -  [https://www.pepper.pl/promocje/shadow-of-the-tomb-raider-definitive-ps4-nowa-pl-297304](https://adguardteam.github.io/AnonymousRedirect/redirect.html?url=https%3A%2F%2Fwww.pepper.pl%2Fpromocje%2Fshadow-of-the-tomb-raider-definitive-ps4-nowa-pl-297304)
2. Click on `Idź do okazji`

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/29142494/92712418-e94d0800-f359-11ea-9358-b398c7f9d3a7.png)

</details>

Link redirects through `redir.tradedoubler.com` which seems to be blocked by DNS filter.