### PR TITLE
fix #453 click.trafficguard.ai

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/453
+@@||click.trafficguard.ai^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/441
 @@||hb.afl.rakuten.co.jp^|
 @@||pt.afl.rakuten.co.jp^|


### PR DESCRIPTION
There are websites which use `click.trafficguard.ai` domain as some kind of redirect engine, should we whitelist this subdomain?