### PR TITLE
Fix #475 tracking.epicgames.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -172,8 +172,6 @@
 ||affirm.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/138
 ||anexia-it.com^
-! https://forum.adguard.com/index.php?threads/35325/
-||tracking.epicgames.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41615
 ||snap.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41294


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/475