### PR TITLE
Fix #506 email.corp.skyeng.ru

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/506
+@@||email.corp.skyeng.ru^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65326
 @@||go.scorptec.com.au^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/468


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/506
![image](https://user-images.githubusercontent.com/8361299/101544910-2784b280-39af-11eb-85dd-f8782735bbde.png)
