### PR TITLE
Fix #510 c.digikey.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/510
+@@||c.digikey.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/506
 @@||email.corp.skyeng.ru^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65326


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/510
email redirects to articles are blocked
![image](https://user-images.githubusercontent.com/8361299/102142405-04ed1080-3e6b-11eb-9ed3-0a5d303e9dfe.png)
