### PR TITLE
email.skyeng.ru

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -8,8 +8,6 @@
 @@||cdn.rozetka.com.ua^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/510
 @@||c.digikey.com^|
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/506
-@@||email.corp.skyeng.ru^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65326
 @@||go.scorptec.com.au^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/468

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -3,7 +3,7 @@
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/517
-@@||email.content.skyeng.ru^|
+@@||email.*.skyeng.ru^|
 ! cdn.rozetka.com.ua is blocked by CNAME 'rozetka-cdn.exponea.com'
 @@||cdn.rozetka.com.ua^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/510


### PR DESCRIPTION
According to the https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/517 and https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/517#issuecomment-748899304, I'm convinced, that it's better to use `*` in this case.
Also removed the old exception.