### PR TITLE
Fix #542 adc.api.nine.com.au

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/542
+||adc.api.nine.com.au^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/540
 ||ahd.ruten.com.tw^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/538


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/542