### PR TITLE
Fix tracemyip.org

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/72064
+||tracemyip.org^
 ! sentry.io bug tracker
 ||sentry.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/544


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/72064
not sure if it is used for tracking. At least whole site should not be blocked.