### PR TITLE
fix #567 com.advanzia.android

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,5 +1,8 @@
 ! Fixing blick.ch
 ||admeira.ch^
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/567
+||etracker.de^
+||etracker.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72744
 ||analitik.edevlet.gov.tr^
 ! plausible - don't break the whole website, blocked plausible.js already


### PR DESCRIPTION
#567

Both domains are required for app to work. First goes `etracker.com` and then `etracker.de`. `||static.etracker.com^` doesn't unlock the app.