### PR TITLE
Fix #577 tracking.magnetmail.net

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/577
+||tracking.magnetmail.net^
 ! Fixing blick.ch
 ||admeira.ch^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72744


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/577
redirection domain