### PR TITLE
Fix #580 cloud.notification-naviextras.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -2,6 +2,8 @@
 ! Once you enable private DNS, Android 9 starts resolving random domains looking like
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/580
+@@||cloud.notification-naviextras.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/568
 @@||email.elitedangerous.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/551


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/580
![image](https://user-images.githubusercontent.com/8361299/107827188-f3eb4d80-6d8e-11eb-8f9b-d75b1036ca03.png)
