### PR TITLE
Added another one Easylist's file with ad severs

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -44,6 +44,7 @@
       "source": "https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_thirdparty.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
+      "inclusions": ["/^\\|\\|[a-z0-9-.]+\\^?(\\$third-party)?$/"],
       "transformations": ["RemoveModifiers", "Validate"]
     },
     {

--- a/configuration.json
+++ b/configuration.json
@@ -40,6 +40,13 @@
       "transformations": ["RemoveModifiers", "Validate"]
     },
     {
+      "name": "EasyList ad servers third-party",
+      "source": "https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_thirdparty.txt",
+      "type": "adblock",
+      "exclusions_sources": ["Filters/exclusions.txt"],
+      "transformations": ["RemoveModifiers", "Validate"]
+    },
+    {
       "name": "AdGuard Mobile Ads filter ad servers",
       "source": "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/MobileFilter/sections/adservers.txt",
       "type": "adblock",

--- a/debug.log
+++ b/debug.log
@@ -1,1 +1,0 @@
-[0217/175320.227:ERROR:registration_protocol_win.cc(102)] CreateFile: Не удается найти указанный файл. (0x2)

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[0217/175320.227:ERROR:registration_protocol_win.cc(102)] CreateFile: Не удается найти указанный файл. (0x2)


### PR DESCRIPTION
Added `https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_thirdparty.txt`
~But it contains not domain rules only. Should it be included to DNS filter?~
`"inclusions": ["/^\\|\\|[a-z0-9-.]+\\^?(\\$third-party)?$/"],` was added in the last commit