### PR TITLE
Fix #573 onesignal.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/573
+||onesignal.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/577
 ||tracking.magnetmail.net^
 ! Fixing blick.ch


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/573
The main purpose of onesignal.com - push notifications