### PR TITLE
address https://github.com/AdguardTeam/AdguardFilters/issues/75194

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/75194
+||pvtag.yahoo.co.jp^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/573
 ||onesignal.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/577


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/75194
Resulting tracking pixel is anyway blocked by other rules.