### PR TITLE
exclude https://6ms.biz/ (nsfw)

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://6ms.biz/
+||6ms.biz^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/573
 ||onesignal.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/577


### PR DESCRIPTION
`6ms.biz` should be blocked only if third-party - https://6ms.biz/ is an adult site.
Added to Japanese filters by
https://github.com/AdguardTeam/AdguardFilters/commit/f2c4c4ceb9471b63ba01c1d535d31a3dd2348f7b#diff-c70d18d94e01db45aa19c2571baec888292d88f27d1bc4143d6fe3e951af5908