### PR TITLE
fix msgs.jp clickthrough

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/626
+||msgs.jp^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/621
 ||logs.datadoghq.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/623


### PR DESCRIPTION
`||msgs.jp^$third-party` from EasyPrivacy, but blocks clickthrough if used in DNS:
ex.
`https://form.bunshun.jp/r/c.do?hw7_jDf_Cw_lrx`
`https://us.msgs.jp/c/PKmF?t1=Jd4N&t2=Uu7T3nbTZc`

There are also legit documents too:
`https://xjeb.cdn.msgs.jp/kf7v/xjeb/FINDS_Targets.pdf`
`https://fqdb.cdn.msgs.jp/zmyf/fqdb/OATHAS_11p_caution.pdf`