### PR TITLE
Update #614

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -3,6 +3,8 @@
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/636
+@@||daikoku.ebis.ne.jp^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/629
 @@||envato.market^|
 ! https://github.com/AdguardTeam/AdguardFilters/pull/76413


### PR DESCRIPTION
Another ebis domain used as click-through, found on `https://kakaku.com/item/K0001321507/?lid=salespr_pm0020_prbox103_direct_30_K0001321507`:

<details>
<summary>Screenshot</summary>

![kakaku](https://user-images.githubusercontent.com/58900598/113888537-657ad180-97fd-11eb-9b88-ca69ccaac697.png)

</details>