### PR TITLE
allow t.afi-b.com clickthrough

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -3,6 +3,8 @@
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/660
+@@||t.afi-b.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/636
 @@||daikoku.ebis.ne.jp^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/629


### PR DESCRIPTION
You can find a link here: `https://endia.net/manga-recommended`
Direct link: `https://t.afi-b.com/visit.php?guid=ON&a=B9476X-V322261a&p=O595240G`
But not sure, allowing this means allowing 3p tracker from the domain too. Exception and not exclusion because EP has `||afi-b.com^$third-party`.