### PR TITLE
Fix #673 albacross.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/673
+||albacross.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/666
 ||kaptcha.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/662


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/673
Tracking domains are blocked in our filter.