### PR TITLE
Fix #685 Exacttarget Marketing Cloud

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -63,6 +63,9 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333
 @@||click.virt.s*.exacttarget.com^|
 @@||click.virt.exacttarget.com^|
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/685
+! Exacttarget Marketing Cloud
+@@||mc.*.exacttarget.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/61592
 @@||login.sendpulse.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/451


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/685

https://subdomainfinder.c99.nl/scans/2021-06-08/exacttarget.com