### PR TITLE
Fix #684 web.de

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/684
+||uim.tifbs.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/690
 ||onlinepbx.ru^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/677


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/684
dangerous rule