### PR TITLE
Fix #735 insight.rapid7.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/735
+||insight.rapid7.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/727
 ||ipcheck.tmgrup.com.tr^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/724


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/735
covered by `||logs.insight.rapid7.com^`