### PR TITLE
Fix #781 citi.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -3,6 +3,9 @@
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/781
+! Blocked by CNAME we-stats.com
+@@||contents*.00110.citi.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/759
 ! Blocked by CNAME impactradius.com
 @@||goto.walmart.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/781

`contents*.00110.citi.com` is blocked as CNAME of `we-stats.com`