### PR TITLE
Fix #776 booktickets.disneylandparis.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/776
+||tagcommander.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/786
 ||sphdigital.com^
 ! fix Honest sign app


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/776