### PR TITLE
Fix #773 tkqlhce.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/773
+||tkqlhce.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/786
 ||sphdigital.com^
 ! fix Honest sign app


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/773
another example
https://toptravel.tv/
+ 
https://publicwww.com/websites/%22tkqlhce.com%22/