### PR TITLE
Fix #805 mtv.fi

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -24,6 +24,8 @@
 @@||goto.walmart.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/743
 @@||citiintl.122.2o7.net^|
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/805
+@@||ma135-r.analytics.edgekey.net^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/89190
 @@||79423.analytics.edgekey.net^|
 ! Blocked by CNAME ||leadpages.net^$third-party


### PR DESCRIPTION
Subdomain is used for this site only.
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/805