### PR TITLE
easyprivacy https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/815

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/815
+||micpn.com^
 ! https://github.com/easylist/easylist/issues/9445
 ||kqzyfj.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/808


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/815

After googling main domain it is used for more e-mail cases, therefore removed from our tracking filter. EasyPrivacy has this rule too.