### PR TITLE
Fix interia.pl

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -3,6 +3,8 @@
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/98729
+@@||ia.hit.interia.pl^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/797
 @@||r.sascdn.com^|
 ! https://forum.adguard.com/index.php?threads/amplitude-com-blocked.45115


### PR DESCRIPTION
Issue - https://github.com/AdguardTeam/AdguardFilters/issues/98729

Images in sliders do not load if `ia.hit.interia.pl` is blocked.


<details>
  <summary>Screenshot 1 - when ia.hit.interia.pl is blocked</summary>

  ![Screenshot 1](https://reports-img.adguard.com/SxRUke7.png)
</details>

<details>
  <summary>Screenshot 2 - when ia.hit.interia.pl is not blocked</summary>

  ![Screenshot 2](https://reports-img.adguard.com/TBKzr9J.png)
</details>