### PR TITLE
Fix #824 i2i.jp

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -3,6 +3,8 @@
 ! `*-dnsotls-ds.metric.gstatic.com` (for instance, `a5a6380f-dnsotls-ds.metric.gstatic.com`).
 !
 !
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/824
+@@||id.i2i.jp^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/98798
 @@||thumbnail.thench.net^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/819


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/824
i2i.jp is used also for ads with many subdomains, so whitelisted the necessary domain.