### PR TITLE
Fixing zmctrack.net ads

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -427,6 +427,7 @@
 ||proofpoint.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26914
 ||zmctrack.net^
+||znctrack.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/33
 ||localbitcoins.com^
 ! https://forum.adguard.com/index.php?threads/30479/

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -425,7 +425,7 @@
 ||anrdoezrs.net^
 ! Fixing proofpoint.com
 ||proofpoint.com^
-! https://github.com/AdguardTeam/AdguardFilters/issues/26914
+! https://github.com/AdguardTeam/AdguardFilters/issues/99952
 ||zmctrack.net^
 ||znctrack.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/33


### PR DESCRIPTION
This domain cannot be blockced completely, because it is hard to bypass this script when domain is blocked