### PR TITLE
Fix #863 db-ip.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/863 
+||db-ip.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/101532
 ||threatbook.cn^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/777


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/863
used for resolve IP to country name.