### PR TITLE
Fix #880 fastly-analytics.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/880
+||fastly-analytics.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/878
 ||ipdata.co^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/875


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/880
https://publicwww.com/websites/%22fastly-analytics.com%22+depth%3Aall/