### PR TITLE
Fix #886 tollfreeforwarding.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/886
+||tollfreeforwarding.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/884
 ||ip-tracker.org^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/880


### PR DESCRIPTION
Not an ad/tracking server
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/886