### PR TITLE
Fix #902 anura.io

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/902
+||anura.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/900
 ||fireworkapi.com^
 ||fireworktv.com^


### PR DESCRIPTION
Added `||script.anura.io^` to our tracking protection filter.