### PR TITLE
Fix #916 adc.api.nine.com.au - possible fix

### DIFF
--- a/Filters/rules.txt
+++ b/Filters/rules.txt
@@ -4,7 +4,6 @@
 ! This domain does not exist and is used for health checks
 ||abcounter.de^
 ||adc.9news.com.au^
-||adc.api.nine.com.au^
 ||adc.nine.com.au^
 ! https://github.com/AdguardTeam/AdguardDNS/issues/52
 ||mobileanalytics.*.amazonaws.com^


### PR DESCRIPTION
Possible fix for https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/916
Can be merged.