### PR TITLE
Fix #920 hsdn.org

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/920
+||hsdn.org^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/914
 ||ping-admin.ru^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/905


### PR DESCRIPTION
Todo: check if `||top.hsdn.org^` appeared in DNS filter.

https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/920