### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/114908 in DNS

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/114908
+@@||torimochi.line-apps.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/937
 @@||oa.tr.line.me^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/115247


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/114908
Still in EasyPrivacy (reported)