### PR TITLE
email.propertybeforeprada.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -70,10 +70,6 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/707
 @@||health.halodoc.com^|
 !
-! https://github.com/AdguardTeam/AdguardFilters/issues/99102
-! Blocked by CNAME ||customer.io^
-@@||email*.123formbuilder.com^|
-!
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/709
 @@||promo.gramedia.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81939

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/946
+||custumer.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/943
 ||branch.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/934


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/946

The domain `email.propertybeforeprada.com` is blocked by **CNAME** `||customer.io^` .

I excluded `||customer.io^` from the DNS filter, due to the fact that it disturbs a large number of sites. 

Also, the exception, added for the site, that broke for the same reason, was removed. 