### PR TITLE
Fix Windows Quick Assistant

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/765
+||monitor.azure.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/946
 ||custumer.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/943


### PR DESCRIPTION
It seems that Windows Quick Assistant doesn't work if `monitor.azure.com` is blocked (if I'm not wrong) - https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/765