### PR TITLE
Fix #971 www.7signal.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/971
+||hscoscdn20.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/963
 ||easysol.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/964


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/971

hscoscdn20.net is used for multiple purposes