### PR TITLE
Fix #993 laposte.fr

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/993
+||tagcommander.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/979
 ||sv.aq.qq.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/975


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/993

The rule is quite problematic, also we have a generic URL exclusion `@@||tagcommander.com^*/tc_$script`