### PR TITLE
Fix #1010 eksiup.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1010
+||eksiup.com^
 ! https://forum.adguard.com/index.php?threads/45115/
 ||amplitude.com^
 ! https://github.com/easylist/easylist/pull/10921


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1010

Blocked `||cdn.eksiup.com^` in filters(used for advertising).