### PR TITLE
Fix #1018 stcblink.nypost.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1018
+! Blocked by CNAME sailthru.com
+@@||stcblink.nypost.com^|
 ! https://old.reddit.com/r/Adguard/comments/wkcvpx/redirect_link_not_working_when_adguard_pro_ios_is/
 @@||link.morningbrew.com^|
 ! https://forum.adguard.com/index.php?threads/incorrect-extension-blocking.49177/#post-223130

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,5 +1,3 @@
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1018
-||stcblink.nypost.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1013
 ||livetex.ru^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1010

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1018
+||stcblink.nypost.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1013
 ||livetex.ru^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1010


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1018


`stcblink.nypost.com` domain is blocked by the **CNAME** rule `||sailthru.com^`


```
; <<>> DiG 9.10.6 <<>> CNAME stcblink.nypost.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 3210
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1280
;; QUESTION SECTION:
;stcblink.nypost.com.		IN	CNAME

;; ANSWER SECTION:
stcblink.nypost.com.	60	IN	CNAME	cb.sailthru.com.