### PR TITLE
Fix #1026

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1026
+@@||affstat.adro.co^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1018
 ! Blocked by CNAME sailthru.com
 @@||stcblink.nypost.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1026

```
;; opcode: QUERY, status: NOERROR, id: 45034
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;affstat.adro.co.	IN	 A

;; ANSWER SECTION:
affstat.adro.co.	3600	IN	A	0.0.0.0
```

blocked by `||adro.co^`
