### PR TITLE
link.androidauthority.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,5 +1,6 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1018
 ! Blocked by CNAME sailthru.com
+@@||link.androidauthority.com^|
 @@||stcblink.nypost.com^|
 ! https://old.reddit.com/r/Adguard/comments/wkcvpx/redirect_link_not_working_when_adguard_pro_ios_is/
 @@||link.morningbrew.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1028

```
dnslookup link.androidauthority.com 94.140.14.14
dnslookup v. 1.5.1
dnslookup result:
;; opcode: QUERY, status: NOERROR, id: 8793
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;link.androidauthority.com.	IN	 A

;; ANSWER SECTION:
link.androidauthority.com.	3600	IN	A	0.0.0.0
```

blocks by CNAME `||sailthru.com^`