### PR TITLE
Revert "game.ero-labs.online"

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,5 +1,3 @@
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1037
-||lfjack.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1032
 ||sailthru.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1024


### PR DESCRIPTION
Reverts AdguardTeam/AdGuardSDNSFilter#1038 and related to https://github.com/easylist/easylist/commit/5ee1b047be3332f4faa58179479e6e36a44b2bbe