### PR TITLE
Fix #1059 metricool.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1059
+||metricool.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1056
 ||ad-shield.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1053


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1059
Removed Easylist's wide rule. We have `||tracker.metricool.com^`