### PR TITLE
add Frellwits Swedish Filter

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -195,6 +195,13 @@
       "transformations": ["RemoveModifiers", "Validate"]
     },
     {
+      "name": "Frellwits Swedish Filter",
+      "source": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Hosts-File.txt",
+      "type": "adblock",
+      "exclusions_sources": ["Filters/exclusions.txt"],
+      "transformations": ["RemoveModifiers", "Validate"]
+    },
+    {
       "name": "EasyList Italy ad servers",
       "source": "https://raw.githubusercontent.com/easylist/easylistitaly/master/easylistitaly/easylistitaly_adservers.txt",
       "type": "adblock",


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1062

Some domains will be excluded because they are on the AdGuard exclusions list