### PR TITLE
fix #134015 tiny.cc

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/134015
+||static.addtoany.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1086
 ||api.ipify.org^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1081


### PR DESCRIPTION
This rule is from Frellwit's Swedish filter.

https://github.com/AdguardTeam/AdguardFilters/issues/134015