### PR TITLE
affiliatly.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! 
+||affiliatly.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/134015
 ||static.addtoany.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1086


### PR DESCRIPTION
This report came from our tech support. I noticed that scripts in most cases are pulled from the subdomain and it makes no sense to block the entire site.