### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/134609

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/134609
+||www.npttech.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/1097
 ||affiliatly.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/134015


### PR DESCRIPTION
They check if it is blocked and then set Adblocker to true according to code. But cannot reproduce.
<script async="true" src="//www.npttech.com/advertising.js" onerror="setNptTechAdblockerCookie(true);"></script>