### PR TITLE
Fix za.zdn.vn - too wide rule

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1104
+||za.zdn.vn^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/134609
 ||www.npttech.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/1097


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1104
Blocks too much.