### PR TITLE
Removed too wide exclusion, which prevents cname filtering

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -563,8 +563,6 @@ clck.yandex.ru
 onecount.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22963
 skimresources.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/19113
-online-metrix.net
 ! https://github.com/AdguardTeam/AdguardDNS/issues/300
 tag.aticdn.net
 ! Fixing Nvidia Shield Tv issue


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/AdguardFilters/issues/134969
Original exclusion was added 3 years ago when fixed https://github.com/AdguardTeam/AdguardFilters/issues/19113

TODO: 
* After merging, check if drfdisvc.walmart.com is blocked.
* Ask to check `TD Bank` iOS app