### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/103564

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/103564
+||docodoco.jp^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1112
 ||captcha-display.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1104


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report
- [x] My code follows [syntax](https://adguard-dns.io/kb/general/dns-filtering-syntax/) of this project
- [x] I have performed a self-review of my own changes
- [x] My changes do not break web sites, apps and files structure

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads
- [x] Website or app doesn't work properly
- [ ] Missed analytics or tracker
- [ ] Filters maintenance

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/103564

1. Your comment

The site is very popular and the rule is causing blank page. Furthermore, is totally blocking their site `www.docodoco.jp`. `docodoco.jp` is not a pure tracker, more of an IP-geolocation service.

2. Screenshots

<details>

<summary>Screenshot:</summary>

![jrtours](https://user-images.githubusercontent.com/58900598/204751250-d402f015-94fe-4c64-98a9-1d533b308077.png)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
