### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/139287

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/139287
+||datadoghq.eu^
 ! https://github.com/AdguardTeam/AdguardFilters/commit/9fdd011b38d7e71aeb44cb4f64c0eebe4e708839#commitcomment-94905191
 ||ippen.space^
 ! Fixing ThreatMetrix fraud prevention


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/139287

Rule comes from EasyPrivacy

https://easylist.to/easylist/easyprivacy.txt

Since I do not know what else is hosted there I decided not to use @@||app.datadoghq.eu^|