### PR TITLE
Fix #1256 snap.licdn.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1256
+||snap.licdn.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1254
 ||adcell.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/145369


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1256
It seems used as a storage. Sample image
`http://snap.licdn.com/tr/images/55379104ee0ab86d5deaa00fa155adfb/tenor.gif`
