### PR TITLE
Fix #1267 autonews.fr

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1267
+||sonar.viously.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1256
 ||snap.licdn.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1254


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1267
analytics are blocked by `||viously.com/*/mt?`
`sonar.viously.com/*/js?w=` is required for the same players.