### PR TITLE
Fix #1269 logz.io

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1269
+||logz.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1267
 ||sonar.viously.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1256


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1269

Used to collect error data