### PR TITLE
Fix #1276 crakmedia.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1276
+||crakmedia.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1272
 ||xapi.ozon.ru^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1269


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1276
Replaced by `||static.ads.crakmedia.com^`