### PR TITLE
Fix #1301 icanhazip.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1301
+||icanhazip.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1298
 ||moshimo.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1260


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1301
Not a tracker. Just returns an IP.