### PR TITLE
Delete reverted rule related to Blue Archive

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,7 +1,5 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/151196
 ||collector.appconsent.io^
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1350
-||log.ngsm.nexon.com^
 ! https://github.com/hagezi/dns-blocklists/issues/1028
 ||recruitics.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1337


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report
- [X] My code follows [syntax](https://adguard-dns.io/kb/general/dns-filtering-syntax/) of this project
- [X] I have performed a self-review of my own changes
- [X] My changes do not break web sites, apps and files structure

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads
- [X] Website or app doesn't work properly
- [ ] Missed analytics or tracker
- [X] Filters maintenance

## What issue is being fixed?

### Enter the issue address

 - https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/1354#issuecomment-1554667449

### Add your comment and screenshots

 - https://github.com/AdguardTeam/AdguardFilters/commit/d961bbbdeca128cfff728be7718d30983054cbd5

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
