### PR TITLE
Fix totaladblock.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! totaladblock.com - is not used to show ads
+||totaladblock.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1369
 ||signalfx.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1349


### PR DESCRIPTION
Not used to show ads directly. This is an promoted site, but not an ad.