### PR TITLE
line25.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! line25.com - not able to accept cookies to use the page
+||ezodn.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/155484
 ||srv.tunefindforfans.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1383


### PR DESCRIPTION
When visiting the page line25.com you cannot accept cookie in order to use the page

https://old.reddit.com/r/Adguard/comments/14r5igr/cannot_access_sites_with_gatekeeperconsentcom/