### PR TITLE
Unblocking only `ezodn.com`

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,6 +1,6 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1412
 ! line25.com - not able to accept cookies to use the page
-@@||ezodn.com^|
+@@|ezodn.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1411
 @@||gate.first-id.fr^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1401

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1412
+! line25.com - not able to accept cookies to use the page
+@@||ezodn.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1411
 @@||gate.first-id.fr^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1401

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,5 +1,3 @@
-! line25.com - not able to accept cookies to use the page
-||ezodn.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/155484
 ||srv.tunefindforfans.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1383


### PR DESCRIPTION
Related to:
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1412
https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/1418#issuecomment-1623130391
Actually, excluding the domain solves the problem, but unblocking it also works on my side, and it's better because its subdomains will be blocked.
