### PR TITLE
Fix listrakbi.com 

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/hagezi/dns-blocklists/issues/1238
+||listrakbi.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/155484
 ||srv.tunefindforfans.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1383


### PR DESCRIPTION
https://github.com/hagezi/dns-blocklists/issues/1238
Replaced by the less wide rule, which blocks tracking only
https://github.com/AdguardTeam/AdguardFilters/commit/6171bc5dad052cc410b315eb76b7942796abd3be