### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/157550 click…

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/157550
+@@||click.cptrack.de^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1412
 ! line25.com - not able to accept cookies to use the page
 @@|ezodn.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/157550

Rule in DNS filter which blocks it:

||cptrack.de^
