### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/158430

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/158430
+||ioam.de^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1437
 ||wpnrtnmrewunrtok.xyz^
 ! https://github.com/hagezi/dns-blocklists/issues/1238


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/158430

Works when script.ioam.de/iam.js is whitelisted. With tracking protection filter only no issue.