### PR TITLE
Fix #1448 tweakers.net

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1448
+||aa.tweakers.nl^
+||ab.tweakers.nl^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1437
 ||wpnrtnmrewunrtok.xyz^
 ! https://github.com/hagezi/dns-blocklists/issues/1238


### PR DESCRIPTION
Content is not avalable when these domains (1p ad server) are blocked and AdGuard ad blocker is not used
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1448