### PR TITLE
Fix #1464 sponsor.nitropay.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1464
+@@||sponsor.nitropay.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157550
 @@||click.cptrack.de^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1412


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1464
used as a link https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1464#issuecomment-1705469670