### PR TITLE
fix www.rakuten.co.jp redirect

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://twitter.com/Red_Frame_P02/status/1706931925779366188
+@@||ad2.trafficgate.net^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1464
 @@||sponsor.nitropay.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157550


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report
- [x] My code follows [syntax](https://adguard-dns.io/kb/general/dns-filtering-syntax/) of this project
- [x] I have performed a self-review of my own changes
- [x] My changes do not break web sites, apps and files structure

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads
- [x] Website or app doesn't work properly
- [ ] Missed analytics or tracker
- [ ] Filters maintenance

## What issue is being fixed?

`https://twitter.com/Red_Frame_P02/status/1706931925779366188`

### Add your comment and screenshots

1. Your comment

Example direct link on `www.rakuten.co.jp`: `https://rd.rakuten.co.jp/s/?R2=https%3A%2F%2Fad2.trafficgate.net%2Ft%2Fr%2F8448%2F1441%2F99636_99636%2F&D2=3.8611.68708.907371.32305900&C3=be41a5ff5056a506564be10496a65d7b3d757f2d`

It seems `ad2.trafficgate.net` is used only for click-through: `https://publicwww.com/websites/%22ad2.trafficgate.net%22/`


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
