### PR TITLE
Fix statcounter.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -187,7 +187,8 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/428
 ! CNAME: paymaya.customlinks.appsflyer.com
 @@||official.paymaya.com^|
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/381
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1499
+@@||www.statcounter.com^|
 @@||gs.statcounter.com^|
 ! Blocked by exacttarget.com alias
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/333

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -188,6 +188,7 @@
 ! CNAME: paymaya.customlinks.appsflyer.com
 @@||official.paymaya.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1499
+@@|statcounter.com^|
 @@||www.statcounter.com^|
 @@||gs.statcounter.com^|
 ! Blocked by exacttarget.com alias


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1499

Tracking domain `c.statcounter.com` is blocked now.
Result after that:

<details>
<summary>Details</summary>

![image](https://github.com/AdguardTeam/AdGuardSDNSFilter/assets/8361299/880690e7-e2e7-4c05-a018-796490fe1493)


</details>
