### PR TITLE
Fix crossroadstoday.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/164402
+||succeedscene.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/162543
 ||cleverpush.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1483


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/164402
succeedscene.com used only as a bait on many sites (not as a rest of adm domains). 