### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/164769

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/164769
+||exponea.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/164582
 ||shopimind.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/164402


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/164769

Webserver also running on that domain. Also unsure which subdomain is tracking.

We already had an exclusion rule, but cannot find it anymore in current file:

https://github.com/AdguardTeam/AdGuardSDNSFilter/commit/cd9bee072666c83edb5adfa1e5db65034c13a86e