### PR TITLE
Fix #1540 seal.globalsign.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1540
+||seal.globalsign.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1532
 ||bdad.123pan.cn^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/164582


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1540

https://www.globalsign.com/en/ssl/secure-site-seal