### PR TITLE
Fix #1549 pendo.io

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1549
+||pendo.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1540
 ||seal.globalsign.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1532


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1549

Added `||app.pendo.io^` to TPF