### PR TITLE
Fix #1569 recommender.scarabresearch.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1569
+@@||recommender.scarabresearch.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/167622
 ! Blocked by CNAME extole.com
 @@||refer.discover.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1569
Blocking of this domain breaks also sliders/recommendations on some sites.