### PR TITLE
battery drain fix

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! Battery drain for apps, e. g. com.reddit.frontpage|com.spotify.music|app.hallow.android|com.adobe.reader|tv.twitch.android.app
+||api2.branch.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1573
 ||debugbear.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1563


### PR DESCRIPTION
Sometimes 5-6 requests to this domain when it is blocked.

! apps, e. g. com.reddit.frontpage|com.spotify.music|app.hallow.android|com.adobe.reader|tv.twitch.android.app

Screenshot for twitch app can be seen her (user disabled DNS protection to see requesting app): https://imgur.com/a/CNG6zR3
