### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/169684 crashlytics.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/169684
+||crashlytics.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1573
 ||debugbear.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1563


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/169684

Rule is from EasyPrivacy list.