### PR TITLE
Fix #1591 app.adjust.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -759,7 +759,7 @@ heroeswm.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7061
 mixpanel.com
 ! https://github.com/AdguardTeam/AdguardDNS/issues/191
-app.adjust.com
+||adjust.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6999
 onvix.tv
 ! https://github.com/AdguardTeam/AdguardDNS/issues/186


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1591
`app.adjust.com` in `exclusions.txt` removes `@@||app.adjust.com^|`