### PR TITLE
Fix #1615 Garena login is blocked

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -398,6 +398,7 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/508
 ||smartasset.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/496
+||js.datadome.co^
 ||datadome.co^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/485
 ||onelink.me^


### PR DESCRIPTION
https://datadome.co/ It used for security purposes.