### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/174620

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/174620
+@@||api.personaclick.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1631
 ! Blocked by CNAME nc0.co
 @@||tms.capitalone.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/174620

In app you have to press at top at A01-Ekstro/Kapida and then the app crashes.

When unblocked it works fine on my Android 14.