### PR TITLE
Fix #1661 pangleglobal.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1661
+||i18n-pglstatp.com^
+!
 ! Private IP address ranges
 ! 10.0.0.0 – 10.255.255.255
 /(?:^\|\|?|^)(10\.?[\d\.*]+)\|{0,1}$/
@@ -7,6 +10,7 @@
 /(?:^\|\|?|^)(172\.(?:1[6-9]|2[0-9]|3[0-1])\.[\d\.*]+)\|{0,1}$/
 ! 192.168.0.0 – 192.168.255.255
 /(?:^\|\|?|^)(192\.168\.?[\d\.*]+)\|{0,1}$/
+!
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1645
 ||tangerine.io^
 ! https://github.com/easylist/easylist/commit/abaeb1ae5518324a10f469d2a40f96b31bd149a8


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1661
It seems it is Akamai's CDN.