### PR TITLE
remove exclusion

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,5 +1,3 @@
-! https://github.com/AdguardTeam/AdguardFilters/issues/174620
-@@||api.personaclick.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1631
 ! Blocked by CNAME nc0.co
 @@||tms.capitalone.com^|

--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,8 +1,6 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1668
 ! Blocked by CNAME nr-data.net
 @@||infra-api.newrelic.com^|
-! https://github.com/AdguardTeam/AdguardFilters/issues/174620
-@@||api.personaclick.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1631
 ! Blocked by CNAME nc0.co
 @@||tms.capitalone.com^|


### PR DESCRIPTION
Blocking rule got removed, broke likely all clients. Initial report ( https://github.com/AdguardTeam/AdguardFilters/issues/24836 ) is having maintenance, so not going to add the blocking rule with $domain.