### PR TITLE
Exclude Chinese GTM too

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -907,6 +907,7 @@ optimizely.com
 ! https://github.com/AdguardTeam/AdguardDNS/issues/59
 dw.cbsi.com
 ! Fixing few generic issues
+googletagmanager-cn.com
 viglink.com
 googletagservices.com
 googletagmanager.com


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report
- [x] My code follows [syntax](https://adguard-dns.io/kb/general/dns-filtering-syntax/) of this project
- [x] I have performed a self-review of my own changes
- [x] My changes do not break web sites, apps and files structure

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads
- [ ] Website or app doesn't work properly
- [ ] Missed analytics or tracker
- [x] Filters maintenance

## What issue is being fixed?

None particular

### Add your comment and screenshots

1. Your comment

GTM is a major source of trouble and as `googletagmanager.com` is already excluded, so is `googletagmanager-cn.com`.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
