### PR TITLE
Fix #1706 trk.klclick.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1706
+||klclick.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/181520
 ||reitingi.lv^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1702


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1706
Domain went from [Liste FR](https://raw.githubusercontent.com/easylist/listefr/master/liste_fr.txt) to the popup filter: 
`||klclick.com^$popup`