### PR TITLE
Fix #1727 hypestat.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1727
+||hypestat.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1720
 ! Blocks omtrdc.net by CNAME
 ||data.adobedc.net^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1727
I can't find using of this service on sites, so maybe can be removed from DNS filter (still exists in TPF for 3p requests).