### PR TITLE
Fix #1736 miclaro.com.hn

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1736
+||bkrtx.com^
+||tags.bkrtx.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1734
 ||ashleymadison.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1727


### PR DESCRIPTION
Request from the script is blocked by another rule.

https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1736