### PR TITLE
fix https://github.com/AdguardTeam/AdguardFilters/issues/187801 sp.se…

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/187801
+@@||res.ads.nicovideo.jp^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1720
 ! Blocked by CNAME data.adobedc.net
 @@||lloydsbankinggroup.tt.omtrdc.net^|


### PR DESCRIPTION
…iga.nicovideo.jp

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report
- [x] My code follows [syntax](https://adguard-dns.io/kb/general/dns-filtering-syntax/) of this project
- [x] I have performed a self-review of my own changes
- [x] My changes do not break web sites, apps and files structure

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads
- [x] Website or app doesn't work properly
- [ ] Missed analytics or tracker
- [ ] Filters maintenance

## What issue is being fixed?

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/issues/187801

### Add your comment and screenshots

1. Your comment

Fixes if contents filtering is not available, while still blocks `https://ads.nicovideo.jp/` used in `https://play.google.com/store/apps/details?id=jp.nicovideo.android` for ads.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
