### PR TITLE
Fix spiegel.de

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/189668
+||benelph.de^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/189242
 ||norstatsurveys.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1752


### PR DESCRIPTION
Related to - https://github.com/AdguardTeam/AdguardFilters/issues/189668#issuecomment-2380074647

Ads are displayed on `spiegel.de` in PWA, more info - https://github.com/AdguardTeam/AdguardFilters/issues/189668#issuecomment-2383493341

It seems that `benelph.de` is used by ads reinjection script to detect adblockers, so unblocking it should fixes ads. 