### PR TITLE
Fix whatfinger.com - not an ad server

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! whatfinger.com - not an ad server
+||whatfinger.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/189668
 ||benelph.de^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/189242


### PR DESCRIPTION
Came from https://github.com/easylist/easylist/commit/350abadf5899708a60d0a5fe3614155e3227afcc