### PR TITLE
fix #192829 cts.vresp.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/192829
+||cts.vresp.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1780
 ! Exclude domain from popup filter, leave tracking subdomains
 ||getresponse.com^


### PR DESCRIPTION
Then domain is used by email newsletters.
https://github.com/AdguardTeam/AdguardFilters/issues/192829