### PR TITLE
Fix #1787 com.zennioptical.app

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1787
+||curalate.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1780
 ! Exclude domain from popup filter, leave tracking subdomains
 ||getresponse.com^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1787
Domains cannot be blocked, because galleries on shop sites will be broken.

Example sites
https://www.canadiantire.ca/en.html
https://www.potterybarn.com/shop/lighting/
https://www.landsend.com/
and the app of report.

Applied `$removeparam` rules and blocked tracking URL in AdGuardFilters, removed obsolete rules there. https://github.com/AdguardTeam/AdguardFilters/commit/a81540eade40dd25063af9b8a2637bd751ee644f