### PR TITLE
Fix #1795 mb.cision.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1795
+||cision.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1789
 ||cxpublic.com^
 ! https://gall.dcinside.com/mgallery/board/view?id=adguard&no=227&fcno=1037&fpno=963


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1795

Can't be blocked by DNS, because some content of sites is hosted here. I don't see separate domains, used for tracking.