### PR TITLE
Fix ynet.co.il

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/195133
+||totalmedia2.ynet.co.il^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1802
 ||cglms.com^
 ! https://github.com/orgs/List-KR/discussions/74


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/195133
Not the best solution - cannot find another way.

**It is required only for Android.** Without DNS filtering used
`@@||totalmedia2.ynet.co.il/new_gpt/ynet_new/mutam/gpt_script_ynet_mutam.js`
If someone suggests a working scriptlet/replace rule - close this PR without merging.