### PR TITLE
Fix #1820 SBS News

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1820
+@@||sbs.demdex.net^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/194309
 @@||cl.link-ag.net^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1784


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1820
u
Checked also the site - this domain is used for adblock detection. Did not see tracking usage, only in email campaigns as click tracking. DNS filtering at the moment breaks links opening.

Blocked some tracking in SBS News emails here: https://github.com/AdguardTeam/AdguardFilters/commit/fdca44085c0cdef07975f7a374a5694a504b3d8a