### PR TITLE
Fix #1824 analytics.pinterest.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1824
+||analytics.pinterest.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1726
 ||app.chat.xiaomi.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1804


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1824

did not find where this domain is used for analytics.