### PR TITLE
Fix #1828 unbouncepages.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1828
+||analytics.avcdn.net^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1824
 ||analytics.pinterest.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1726

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,5 +1,5 @@
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1828
-||analytics.avcdn.net^
+||unbouncepages.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1824
 ||analytics.pinterest.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1726


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1828
> Unbounce isn't an advertisement platform or an analytics provider. It's a landing page builder.

It is true. In EasyList Hebrew it just blocks opening the links, not banners.