### PR TITLE
Fix #1854 smtp.focusgroupresearch.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1854
+! Blocked by CNAME tracking.socketlabs.com
+@@||smtp.focusgroupresearch.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/199304
 @@||ap01.records.in.treasuredata.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1840


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1854