### PR TITLE
Fix #1860 bigpulpit.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1860
+||bigpulpit.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/199829
 ||adimg.nate.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1838


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1860

Not an ad server. Just their banners on few sites of similar subject.