### PR TITLE
Fix #1843 convertbox.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1843
+||convertbox.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1860
 ||bigpulpit.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/199829


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1843
Replaced by less wide rule.