### PR TITLE
Fix #1852 api2.branch.io - obsolete rule

### DIFF
--- a/Filters/rules.txt
+++ b/Filters/rules.txt
@@ -573,7 +573,3 @@
 !
 ! Special block section, requires explanation for the rule
 !
-! https://reddit.com/r/Adguard/comments/ztbv96/how_do_i_stop_this_my_phone_is_overheating_and/
-! reddit app is unblocked in Mobile filter: https://github.com/AdguardTeam/AdguardFilters/commit/78dd815df59d98fb8b6d658330041b65269eabc2
-||api2.branch.io^$dnsrewrite=0.0.0.0
-!


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1852
It is obsolete, because `0.0.0.0` IP is default response for blocked domains for some time now (DNS and apps).