### PR TITLE
Fix #1857 shrinkearn.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1857
+||shrinkearn.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1843
 ||convertbox.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1860


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1857

Only one ad image hosted on the domain. The main purpose - paid URL shortener on trash sites.