### PR TITLE
Fix www3.doubleclick.net - popular anti-adblock bait

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! Popular anti-adblock bait
+@@|www3.doubleclick.net^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1879
 ! Blocked by the rule, required for blocking Ingenious Technologies analytics
 @@||acs-m.daraz.pk^|


### PR DESCRIPTION
EasyList does not block whole `doubleclick.net`. 
`||doubleclick.net^$popup` converted to `||doubleclick.net^` and `www3.doubleclick.net` is blocked.
I did not find any non-antiadblock usage.

`@@|` - to unblock only `www3.doubleclick.net` without sub-domains.