### PR TITLE
Fix #1882 click.ru

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1882
+||click.ru^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/203738
 ||sw.broadcom.com^
 ! https://github.com/Cats-Team/AdRules/issues/225


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1882
Replaced by `||af.click.ru^`