### PR TITLE
Fix #1884 vivocha.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1884
+||vivocha.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1882
 ||click.ru^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/203738


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1884
it is a chat bot.
Tracking is blocked by `||i1.vivocha.com/a/*/api/vvct.gif?ev=`