### PR TITLE
Fix #1900 firstpromoter.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1900
+||firstpromoter.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1898
 ||brevo.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/205818


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1900

replaced by 

```
||t.firstpromoter.com^
||cdn.firstpromoter.com^$third-party
```