### PR TITLE
Fix #1905 betfair.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1905
+||betfair.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1895
 ||eu-mobile.events.data.microsoft.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1900


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1905

`||ads.betfair.com^` will be used instead.