### PR TITLE
Fix mairdumont.com 

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/hagezi/dns-blocklists/issues/6459
+||mairdumont.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1905
 ||betfair.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1895


### PR DESCRIPTION
We have `||tag.partner.mairdumont.com^$third-party`, and exluded rule will be replaced by `||tag.partner.mairdumont.com^` in the DNS filter.

https://github.com/hagezi/dns-blocklists/issues/6459