### PR TITLE
Fix intel.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/207905
+||dogo.intel.com^
 ! https://github.com/hagezi/dns-blocklists/issues/6459
 ||mairdumont.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1905


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/FiltersRegistry/pull/1096 and https://github.com/AdguardTeam/AdguardFilters/issues/207905

Fixes problem with downloading files on `intel.com`.