### PR TITLE
Fix bentonow.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/commit/a55eb73eb0439f7d95a7981457172f0f059569ff#commitcomment-163113893
+||bentonow.com^
 ! https://github.com/AdguardTeam/CoreLibs/issues/1971#issuecomment-3131079404
 ||veta.naver.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/209715


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/commit/a55eb73eb0439f7d95a7981457172f0f059569ff#commitcomment-163113893
Replaced by `||track.bentonow.com^`