### PR TITLE
Fix usefathom.com - replaced the rule

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,4 +1,5 @@
 ! https://github.com/AdguardTeam/AdguardFilters/commit/a55eb73eb0439f7d95a7981457172f0f059569ff#commitcomment-163113893
+||usefathom.com^
 ||bentonow.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/210099
 ||i.posthog.com^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/commit/a55eb73eb0439f7d95a7981457172f0f059569ff#commitcomment-163105209

Replaced by
https://github.com/AdguardTeam/AdguardFilters/commit/25ae8b54fd9a8621153aa1cad2d44f01c66b9fb4