### PR TITLE
Fix adsafeprotected.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,5 +1,6 @@
 ! Used as popular anti-adblock bait on many sites, prevents the use of websites
 ||adsafeprotected.com^
+||static.adsafeprotected.com^
 ! https://github.com/AdguardTeam/AdguardFilters/commit/a55eb73eb0439f7d95a7981457172f0f059569ff#commitcomment-163113893
 ||usefathom.com^
 ||bentonow.com^


### PR DESCRIPTION
Some popular sites uses static.adsafeprotected.com in anti-adblock checks (sure, in addition to analytics)

The most recent - https://www.cwtv.com/

We need to decide whether to unblock this domain.