### PR TITLE
Removed exclusion of google analytics

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -448,8 +448,6 @@
 ||insight.rapid7.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/727
 ||ipcheck.tmgrup.com.tr^
-! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/724
-||analytics.google.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/88390
 ||airbrake.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/723


### PR DESCRIPTION
It is just analytics

<details>
<summary>Details</summary>

<img width="3745" height="1793" alt="image" src="https://github.com/user-attachments/assets/2fbbc895-49a0-42fe-835e-5e89fc0f053b" />


</details>

Still used for the dashboard https://analytics.google.com/analytics/web/provision/#/provision 
But who uses filtering DNS for advertising and analytics?