### PR TITLE
Fix #1939 monetag.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1939
+||monetag.com^
 ! https://github.com/AdguardTeam/AdguardFilters/commit/a55eb73eb0439f7d95a7981457172f0f059569ff#commitcomment-163113893
 ||usefathom.com^
 ||bentonow.com^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1939

Checked on urlscan.io - not used for hosting ads.