### PR TITLE
Fix partners.sentinelone.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/211060
+! Blocked by CNAME treehousei.com
+@@||prod.impartner.live^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/210955
 ! Blocked by CNAME publisher1st.com
 @@||cdn.atmedia.hu^|


### PR DESCRIPTION
Fixes https://github.com/AdguardTeam/AdguardFilters/issues/211060
`prod.impartner.live` is blocked by CNAME `treehousei.com`.