### PR TITLE
Fix #1941 p.typekit.net

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1941
+||p.typekit.net^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/211591
 ||alicdn.com^
 ||aliexpress-media.com^


### PR DESCRIPTION
Fix #1941

The `p.typekit.net/p.css` URLs are the same for different users.