### PR TITLE
Fix news.warhammer.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/212351
+! Blocked by CNAME slgnt.eu
+@@||news.warhammer.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/211060
 ! Blocked by CNAME treehousei.com
 @@||prod.impartner.live^|


### PR DESCRIPTION
Fixes https://github.com/AdguardTeam/AdguardFilters/issues/212351
`news.warhammer.com` is blocked by CNAME `slgnt.eu`.