### PR TITLE
Fix news.gifi.fr

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/211724
+! Blocked by CNAME slgnt.eu
+@@||news.gifi.fr^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/212351
 ! Blocked by CNAME slgnt.eu
 @@||news.warhammer.com^|


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/AdguardFilters/issues/211724
I'm not sure if it will fixes issue with images, but `news.gifi.fr` is blocked by CNAME `slgnt.eu`, so perhaps it helps.

By the way, it's second similar report recently (https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/1951), perhaps we should consider to exclude `slgnt.eu` from DNS filter?
Added in https://github.com/AdguardTeam/AdguardFilters/commit/839fa5f050c01fc323d9dfd6172acd2274d939e4