### PR TITLE
Fix #1953 playhydrax.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1953
+||playhydrax.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/211477
 ||udc.yahoo.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1941


### PR DESCRIPTION
Fixing incorrect blocking by `AdGuard DNS Popup Hosts filter`. Used as video CDN, like [here](https://animefever.cc/watch/glass-mask-2005.18662?ep=50970)
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1953