### PR TITLE
Fix: analytics.google.com (again)

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -459,6 +459,8 @@
 ||insight.rapid7.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/727
 ||ipcheck.tmgrup.com.tr^
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1955
+||analytics.google.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/88390
 ||airbrake.io^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/723


### PR DESCRIPTION
# Creating the pull request

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report
- [X] My code follows [syntax](https://adguard-dns.io/kb/general/dns-filtering-syntax/) of this project
- [X] I have performed a self-review of my own changes
- [X] My changes do not break web sites, apps and files structure

## What problem does the pull request fix?

Google Analytics website dashboard no longer accessible

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads
- [X] Website or app doesn't work properly
- [ ] Missed analytics or tracker
- [ ] Filters maintenance

## What issue is being fixed?

Google Analytics website dashboard not accessible

### Enter the issue address

- Fixes: https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1955

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

1. Your comment

Previously excluded in 

- https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/724

And multiple other times, at the rate of about once a year.

I can gain access by not using AdGuard DNS (eg. using VPN)


2. Screenshots

<details>

<summary>Screenshot 1:</summary>

<img width="1392" height="1059" alt="Screen shot 2025-09-07 at 15 28 48" src="https://github.com/user-attachments/assets/28b5d8a3-0c57-4946-8ad9-7cdc38f2b7ad" />

</details>

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
