### PR TITLE
newyorker.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/215116
+@@||puzzles-games-api.gp-prod.conde.digital^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/212351
 ! Blocked by CNAME slgnt.eu
 @@||news.warhammer.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/215116.
It's been confirmed that unblocking the mentioned domain [helps](https://github.com/AdguardTeam/AdguardFilters/issues/215116#issuecomment-3382052107).