### PR TITLE
Fix #1964 Pluto TV app live TV broken

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1964
+||youborafds01.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1953
 ||playhydrax.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/211477


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1964
Still blocked in the TPF + domain specific unblocking rule.

Pluto is very popular.
