### PR TITLE
Revert https://github.com/AdguardTeam/AdGuardSDNSFilter/pull/14

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -871,8 +871,6 @@ webtrends.com
 host-tracker.com
 ! fixing redirects in Yandex apps
 clck.yandex.ru
-! https://github.com/AdguardTeam/AdguardFilters/issues/24120
-||litix.io^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24174
 onecount.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22963


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/215201

At the moment Discovery is no broken by this rule.

https://www.investigationdiscovery.com/video/mother-may-i-murder-investigation-discovery-atve-us/sex-lies-and-murder