### PR TITLE
Fix #1976 go.redirectingat.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1976
+@@||go.redirectingat.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/215941
 ! Blocked by CNAME servedbyadbutler.com
 @@||ref.rbauction.com^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1976

used not only in ads - promotions in mailings and on websites.