### PR TITLE
Fix cn.pccomponentes.pt

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/hagezi/dns-blocklists/issues/8005
+||connectif.cloud^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1978
 ||trackjs.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1971


### PR DESCRIPTION
https://github.com/hagezi/dns-blocklists/issues/8005

tracking will be blocked by these rules
https://github.com/AdguardTeam/AdguardFilters/commit/28a668fc635d557aa99dc4480e52e9853e34c740
cdn.connectif.cloud - by DNS, requests to *-api.connectif.cloud are made from cdn.connectif.cloud script.