### PR TITLE
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1985

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1985
+@@||itoya.ec-optimizer.com^|
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1976
 @@||go.redirectingat.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/215941


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1985

The exclusion is site-specific, only for ito-ya.co.jp