### PR TITLE
Fix #1987 data.service.paypal.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1987
+||data.service.paypal.com^
 ! https://github.com/hagezi/dns-blocklists/issues/8005
 ||connectif.cloud^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1978


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/219743

Used in PayPal's links

<img width="582" height="181" alt="image" src="https://github.com/user-attachments/assets/add58074-2293-45fd-8839-c07d0e824cd6" />
