### PR TITLE
Fix #1992 go.redirectingat.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1992
+||redirectingat.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1987
 ||data.service.paypal.com^
 ! https://github.com/hagezi/dns-blocklists/issues/8005


### PR DESCRIPTION
For `AdGuard DNS Popup Hosts filter`