### PR TITLE
Fix #2001 link.meet5.net

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2001
+@@||link.meet5.net^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/220979
 ! Blocked by CNAME moengage.com
 @@||link.nzz.ch^|


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2001
It unblocks only email links.