### PR TITLE
Fix #2003 data.orders.costco.com

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,4 +1,7 @@
-! ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2001
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2003
+! Blocked by CNAME data.adobedc.net
+@@||data.orders.costco.com^|
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2001
 @@||link.meet5.net^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/220979
 ! Blocked by CNAME moengage.com


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2003

Unblocks `data.orders.costco.com` and `sms.orders.costco.com`. Both are required for this site/app.