### PR TITLE
Fix #1690 Unblock api-ao-list.adison.co in Adguard DNS filter

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -153,6 +153,7 @@
 /(?:^\|\|?|^)(192\.168\.?[\d\.*]+)\|{0,1}$/
 !
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1690
+||api-ao.adison.co^
 ||api-ao-list.adison.co^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1645
 ||tangerine.io^


### PR DESCRIPTION
Same issue https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1690

Not removed from AdGuard Base filter.