### PR TITLE
Fix #2021 fd.cleantalk.org

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2021
+||fd.cleantalk.org^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2011
 ||log.go.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1992


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2021
ant-bot protection. Protected features on sites are broken when this script is blocked.