### PR TITLE
Fix #2025 www.jafco.co.jp

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,6 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/224298
+! Blocked by CNAME popcashjs.b-cdn.net
+||consent.cookiefirst.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2023
 ||netcore.co.in^
 ||tw.netcore.co.in^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2025
This domain must be (is) blocked by AdGuard Cookie Notices filter