### PR TITLE
Fix #2031 blossoms.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2031
+||blossoms.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/224298
 ! Blocked by CNAME popcashjs.b-cdn.net
 ||consent.cookiefirst.com^


### PR DESCRIPTION
Not an ad (possibly use aggressive marketing)
https://en.wikipedia.org/wiki/Cherry_Blossoms_(marriage_agency)