### PR TITLE
Fix #2033 www.wired.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2033
+||martech.condenastdigital.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2031
 ||blossoms.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/224298


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2033

blocking this domain by DNS breaks subscription flow on sites of [Condé Nast](https://www.condenast.com/) media company.