### PR TITLE
Fix #2035 moengage.com

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2035
+||moengage.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2033
 ||martech.condenastdigital.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2031


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2035

to not block links in emails by CNAME `bapi-01.moengage.com`

In regular filter replaced by `cdn.moengage.com` (also two old rules present). They will be loaded to DNS filter after excluding the wide one.