### PR TITLE
Fix log.onmas.kt.com exclusion for KT app

### DIFF
--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/226920
+||log.onmas.kt.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227203
 ! Blocked by CNAME cdn50181425.ahacdn.me
 ||static2.manualslib.com^


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report
- [x] My code follows [syntax](https://adguard-dns.io/kb/general/dns-filtering-syntax/) of this project
- [x] I have performed a self-review of my own changes
- [x] My changes do not break web sites, apps and files structure

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads
- [x] Website or app doesn't work properly
- [ ] Missed analytics or tracker
- [ ] Filters maintenance

## What issue is being fixed?

### Enter the issue address

This commit is aligned with https://github.com/AdguardTeam/AdguardFilters/pull/227593.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
