### PR TITLE
Fix `unsubscribe.lhinsights.com`

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,5 @@
+! https://github.com/AdguardTeam/AdguardFilters/issues/230786
+@@||unsubscribe.lhinsights.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227852
 ! Blocked by CNAME s1364398973.hs.eloqua.com
 @@||belgium.wolterskluwer.com^|


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/AdguardFilters/issues/230786.