### PR TITLE
Fix #2053 et-gv.fr blocking by CNAME issue

### DIFF
--- a/Filters/exceptions.txt
+++ b/Filters/exceptions.txt
@@ -1,3 +1,6 @@
+! https://x.com/Quarters8699/status/2052215338989953157
+! Blocked by CNAME ebis.ne.jp
+@@||ad.kddi-fs.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/230786
 @@||unsubscribe.lhinsights.com^|
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227852

--- a/Filters/exclusions.txt
+++ b/Filters/exclusions.txt
@@ -1,6 +1,5 @@
-! https://x.com/Quarters8699/status/2052215338989953157
-! Blocked by CNAME ebis.ne.jp
-||ad.kddi-fs.com^
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2053
+||et-gv.fr^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2041
 ! Blocked by CNAME data.adobedc.net
 ||subscriptions.costco.com^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2053

Blocking et-gv.fr / gva.et-gv.fr causes blocking hundreds of domains by CNAME.

And moved one rule to correct place.